### PR TITLE
Added combat loop

### DIFF
--- a/Assets/Resources/Script/CombatManager/UnitObject.cs
+++ b/Assets/Resources/Script/CombatManager/UnitObject.cs
@@ -9,6 +9,12 @@ public enum eRollType {
     FULLGRID
 }
 
+public enum eUnitPosition {
+    NONE,
+    FRONT,
+    BACK
+}
+
 public class UnitObject : MonoBehaviour {
     [field: SerializeField] public UnitScriptableObject unitSO { get; private set; }
     [SerializeField] EffectList _listEffect;
@@ -22,6 +28,8 @@ public class UnitObject : MonoBehaviour {
 
     float _currentHealth = 0.0f;
     float _currentShield = 0.0f;
+    eUnitPosition _ePosition = eUnitPosition.NONE;
+    public bool IsFrontPosition() { return _ePosition == eUnitPosition.FRONT; }
 
     bool _bIsDead = false;
     public bool IsDead() { return _bIsDead; }
@@ -66,16 +74,12 @@ public class UnitObject : MonoBehaviour {
             return;
         }
 
-        float fDamageAfterShield = damage - _currentShield;
-        if (fDamageAfterShield < 0) {
-            _currentShield = Mathf.Abs(fDamageAfterShield);
-            return;
-        }
-
-        _currentHealth -= fDamageAfterShield;
+        float fFinalDamage = _GetDamageAfterShield(damage);
+        _currentHealth -= fFinalDamage;
         if (_currentHealth <= 0.0f) {
             _TriggerDeath();
         }
+        Global.DEBUG_PRINT("Final Damage=" + fFinalDamage);
     }
 
     public float GetHealthPercentage() {
@@ -84,19 +88,30 @@ public class UnitObject : MonoBehaviour {
 
     public EffectList GetEffectList(eRollType eType) {
         switch (eType) {
-        case eRollType.SINGLE:
-            return _listSingleEffect;
-        case eRollType.DIAGONAL:
-            return _listDiagonalEffect;
-        case eRollType.ZIGZAG:
-            return _listZigZagEffect;
-        case eRollType.XSHAPE:
-            return _listXShapeEffect;
-        case eRollType.FULLGRID:
-            return _listFullGridEffect;
+            case eRollType.SINGLE:
+                return _listSingleEffect;
+            case eRollType.DIAGONAL:
+                return _listDiagonalEffect;
+            case eRollType.ZIGZAG:
+                return _listZigZagEffect;
+            case eRollType.XSHAPE:
+                return _listXShapeEffect;
+            case eRollType.FULLGRID:
+                return _listFullGridEffect;
         }
-        
+
         return null;
+    }
+
+    float _GetDamageAfterShield(float damage) {
+        damage -= _currentShield;
+        if (damage > 0) {
+            _currentShield = 0;
+            return damage;
+        }
+
+        _currentShield = Mathf.Abs(damage);
+        return 0;
     }
 
     void _TriggerDeath() {

--- a/Assets/Resources/Script/DeckManager/Deck.cs
+++ b/Assets/Resources/Script/DeckManager/Deck.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class Deck : IEnumerable<UnitObject> {
     List<UnitObject> _vecUnit = new List<UnitObject>();
     List<Transform> _vecPosition = new List<Transform>();
+    public int GetDeckMaxSize() { return _vecPosition.Count; }
 
     public void Init(List<Transform> vecPos) {
         _vecPosition = vecPos;
@@ -43,6 +44,14 @@ public class Deck : IEnumerable<UnitObject> {
         }
 
         return _vecUnit[index];
+    }
+
+    public bool IsValidUnitIndex(int index) {
+        if (index < 0 || index >= _vecUnit.Count) {
+            return false;
+        }
+
+        return true;
     }
 
     Transform _GetPosition() {

--- a/Assets/Resources/Script/DeckManager/DeckManager.cs
+++ b/Assets/Resources/Script/DeckManager/DeckManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public enum eDeckType {
+    NONE,
     PLAYER,
     ENEMY,
 }

--- a/Assets/Resources/Script/Global.cs
+++ b/Assets/Resources/Script/Global.cs
@@ -1,8 +1,9 @@
 using UnityEngine;
-using System.Collections.Generic;
 
 public static class Global {
-    public const int GRID_SIZE = 3; 
+    public const int GRID_SIZE = 3;
+    public const int PERCENTAGE_CONSTANT = 100;
+    public const int RESISTANCE_PERCENTAGE_CONSTANT = 10;
     public static bool IS_DEBUG = true;
 
     // Simulation test for Darren&Tianyu to verify all kinds of complicated scenarios

--- a/Assets/Resources/Utils/Timer.meta
+++ b/Assets/Resources/Utils/Timer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: efb2d12b2b346534a97cdc5c73464589
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Utils/Timer/CustomTimer.cs
+++ b/Assets/Resources/Utils/Timer/CustomTimer.cs
@@ -1,0 +1,38 @@
+using System;
+using UnityEngine;
+
+public class CustomTimer {
+    float _fCurrentTimer = 0.0f;
+
+    float _fTimeToAct = 0.0f;
+    public void SetTime(float time) { _fTimeToAct = time; }
+
+    Action _func;
+    public void SetFunc(Action func) { _func = func; }
+
+    bool _bActive = false;
+
+    // Update is called once per frame
+    public void Update() {
+        if (!_bActive) {
+            return;
+        }
+        
+        if (_fCurrentTimer < _fTimeToAct) {
+            _fCurrentTimer += Time.deltaTime;
+            return;
+        }
+
+
+        if (_func != null) {
+            _func();
+        }
+        _fCurrentTimer = 0.0f;
+        _bActive = false;
+    }
+
+    public void Reset() {
+        _bActive = true;
+        _fCurrentTimer = 0.0f;
+    }
+}


### PR DESCRIPTION
# Type Of Change
<!-- Describe type of change in this pull request -->
- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Misc

## Description
Added combat loop
it will go in this order:
Player 1
Player 2
Player 3
Enemy 1
Enemy 2
Enemy 3

it should work for any amount of units on each side

## Testing Instructions
press 1 and 2 to add units on player/enemy side
press 3 to start combat loop

## Example Output
player attack first
enemy attack after