### PR TITLE
Misc: Fix tooltip and dialogue bug

### DIFF
--- a/Assets/Resources/Script/MapManager/MapManager.cs
+++ b/Assets/Resources/Script/MapManager/MapManager.cs
@@ -73,13 +73,18 @@ namespace Map
             PlayerPrefs.Save();
         }
 
-        private void OnApplicationQuit() 
+        public void CleanUpMap()
         {
             PlayerPrefs.DeleteKey("Map");
             PlayerPrefs.DeleteKey("ScrollPositionX");
             PlayerPrefs.DeleteKey("ScrollPositionY");
             PlayerPrefs.DeleteKey("ScrollPositionZ");
             PlayerPrefs.Save();
+        }
+
+        private void OnApplicationQuit() 
+        {
+            CleanUpMap();
             Global.DEBUG_PRINT("[MapManager::OnApplicationQuit] Map and scroll position cleared from PlayerPrefs");
         }
     }

--- a/Assets/Resources/Script/MapManager/MapPlayerTracker.cs
+++ b/Assets/Resources/Script/MapManager/MapPlayerTracker.cs
@@ -9,7 +9,8 @@ namespace Map
     /// Handles node selection, path progression, node accessibility, and triggers node entry logic.
     /// Ensures only valid nodes can be selected based on the current path and node connections.
     /// Supports locking after selection and delayed node entry for animation or transition effects
-    public class MapPlayerTracker : MonoBehaviour {
+    public class MapPlayerTracker : MonoBehaviour 
+    {
         /// If true, the tracker will lock after a node is selected, preventing further selections 
         /// until unlocked
         public bool lockAfterSelecting = false;
@@ -93,9 +94,10 @@ namespace Map
             // If choose to show GUI in some of these cases, do not forget to set "Locked" in MapPlayerTracker back to false
             switch (mapNode.Node.nodeType) {
                 case NodeType.Enemy:
-                    // mapManager.SaveMap();
-                    // EnemyManager.instance.nodeType = mapNode.Node.nodeType;
-                    // SceneManager.LoadScene("Game");
+                    mapManager.SaveMap();
+                    EnemyManager.instance.nodeType = mapNode.Node.nodeType;
+                    EnemyManager.instance.PopulateMobBasedOnNodeType();
+                    SceneManager.LoadScene("Game");
                     break;
                 case NodeType.Encounter:
                     mapManager.SaveMap();
@@ -114,9 +116,10 @@ namespace Map
                     SceneManager.LoadScene("Game_Blacksmith");
                     break;
                 case NodeType.MiniBoss:
-                    // mapManager.SaveMap();
-                    // EnemyManager.instance.nodeType = mapNode.Node.nodeType;
-                    // SceneManager.LoadScene("Game");
+                    mapManager.SaveMap();
+                    EnemyManager.instance.nodeType = mapNode.Node.nodeType;
+                    EnemyManager.instance.PopulateMobBasedOnNodeType();
+                    SceneManager.LoadScene("Game");
                     break;
                 case NodeType.MajorBoss:
                     mapManager.SaveMap();
@@ -130,10 +133,9 @@ namespace Map
             Locked = false;
         }
 
-        // Example stub for starting the boss fight (implement as needed)
-        // private static void StartMajorBossFight(MapNode mapNode)
-        // {
-        //     // Start the fight, then call OnMajorBossResult(true/false) when done
-        // }
+        public void CleanUpMap()
+        {
+            mapManager.CleanUpMap();
+        }
     }
 }

--- a/Assets/Resources/Script/StoryTellerManager/StoryTellerManager.cs
+++ b/Assets/Resources/Script/StoryTellerManager/StoryTellerManager.cs
@@ -24,7 +24,7 @@ public class StoryTellerManager : MonoBehaviour
     [Header("Sample Content Pools")]
     public Sprite goldIcon;
     public int minGold = 5;
-    public int maxGold = 20;
+    public int maxGold = 15;
 
     private MockItemType finalMockItemType;
     private UnitObject finalUnitObject;

--- a/Assets/Resources/Script/UIManager/ToolTip/ToolTipDetails.cs
+++ b/Assets/Resources/Script/UIManager/ToolTip/ToolTipDetails.cs
@@ -48,4 +48,12 @@ public class ToolTipDetails : MonoBehaviour, IPointerEnterHandler, IPointerExitH
         hasMouseOver = false;
         ToolTipManager.Instance.Hide();
     }
+
+    // Ensures tooltip is hidden when this component is disabled
+    void OnDisable()
+    {
+        if (ToolTipManager.Instance != null) {
+            ToolTipManager.Instance.Hide();
+        }
+    }
 }

--- a/Assets/Scenes/Game_StoryTeller.unity
+++ b/Assets/Scenes/Game_StoryTeller.unity
@@ -577,8 +577,8 @@ MonoBehaviour:
   fadeDuration: 0.5
   dialogueManager: {fileID: 1642342694}
   goldIcon: {fileID: 0}
-  minGold: 20
-  maxGold: 50
+  minGold: 5
+  maxGold: 15
 --- !u!1 &866511348
 GameObject:
   m_ObjectHideFlags: 0
@@ -3536,7 +3536,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 2, y: -4, z: 0}
@@ -3581,7 +3581,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 5, y: -4, z: 0}
@@ -3596,7 +3596,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 6, y: -4, z: 0}
@@ -3926,7 +3926,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -8, y: -2, z: 0}
@@ -3941,7 +3941,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -7, y: -2, z: 0}
@@ -3956,7 +3956,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -6, y: -2, z: 0}
@@ -4136,7 +4136,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 6, y: -2, z: 0}
@@ -4331,7 +4331,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 1, y: -1, z: 0}
@@ -4586,7 +4586,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 0, y: 0, z: 0}
@@ -6586,7 +6586,7 @@ PrefabInstance:
     - target: {fileID: 1583076816284954302, guid: 958e649594c5e0d439f6dd7e64c5313f, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: -7786538801905712091, guid: b04621f87db561d42b5d13d577608ac9, type: 3}
+      objectReference: {fileID: -357196347, guid: 47420a11b80979a46bcf3761a07004e4, type: 3}
     - target: {fileID: 2927566197853561222, guid: 958e649594c5e0d439f6dd7e64c5313f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -6614,6 +6614,14 @@ PrefabInstance:
     - target: {fileID: 3117695645989698249, guid: 958e649594c5e0d439f6dd7e64c5313f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3117695645989698249, guid: 958e649594c5e0d439f6dd7e64c5313f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3117695645989698249, guid: 958e649594c5e0d439f6dd7e64c5313f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3117695645989698249, guid: 958e649594c5e0d439f6dd7e64c5313f, type: 3}
       propertyPath: m_AnchoredPosition.x


### PR DESCRIPTION
# Type Of Change
<!-- Describe type of change in this pull request -->
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Misc

## Description
<!-- Describe the changes in this pull request -->
- Fix tooltip still showing when game object is destroyed
- Fix dialogue bug where it will show error when clicking too fast on the dialogue session
- Added 'Map.MapPlayerTracker.Instance.CleanUpMap();' to be used to reload fresh new map when player is defeated
- Fix gold bug when getting more than set amount (5-15), e.g. was getting like 30-40 gold in encounter scene
- Misc beautifying

## Related Issues
<!-- Link to any related issues or tasks -->

## Testing Instructions
<!--  Provide steps to test these changes -->

## Example Output
<!--  Provide output as screenshot or video to view expected changes -->