### PR TITLE
Misc: Fix bugs on Fikrul's shit

### DIFF
--- a/Assets/Resources/Script/DeckManager/Deck.cs
+++ b/Assets/Resources/Script/DeckManager/Deck.cs
@@ -35,7 +35,7 @@ public class Deck : IEnumerable<UnitObject> {
     }
 
     public void RemoveUnit(UnitObject unit) {
-        if (!IsValidUnitIndex(unit.index)) {
+        if (!IsValidUnitIndex(unit.index) || _vecUnit.Contains(unit) == false) {
             return;
         }
 

--- a/Assets/Resources/Script/GoldManager/GoldManager.cs
+++ b/Assets/Resources/Script/GoldManager/GoldManager.cs
@@ -8,7 +8,7 @@ public class GoldManager : MonoBehaviour
     [SerializeField] private GoldConfig config;
     
     [Header("Gold Settings")]
-    [SerializeField] private int currentGold = 40;
+    [SerializeField] private int currentGold = 15;
 
     private void Awake()
     {
@@ -27,6 +27,12 @@ public class GoldManager : MonoBehaviour
         {
             Destroy(gameObject);
         }
+    }
+
+    public void ResetGold()
+    {
+        currentGold = 15; // Reset to default value
+        Global.DEBUG_PRINT("[GoldManager] Gold reset to default: " + currentGold);
     }
 
     void Start()

--- a/Assets/Resources/Script/MapManager/MapPlayerTracker.cs
+++ b/Assets/Resources/Script/MapManager/MapPlayerTracker.cs
@@ -113,7 +113,7 @@ namespace Map
         /// Handles the logic for entering a node, such as loading a new scene or triggering events based on node type
         private void EnterNode(MapNode mapNode) 
         {
-            // We have access to blueprint name here as well
+            // We have access to blueprint name here as well.
             Global.DEBUG_PRINT("[MapPlayerTracker::EnterNode] Entering node: " + mapNode.Node.blueprintName + " of type: " + mapNode.Node.nodeType);
             // Load appropriate scene with context based on nodeType:
             // If choose to show GUI in some of these cases, do not forget to set "Locked" in MapPlayerTracker back to false

--- a/Assets/Resources/Script/ShopManager/ShopManager.cs
+++ b/Assets/Resources/Script/ShopManager/ShopManager.cs
@@ -94,8 +94,10 @@ public class ShopManager : MonoBehaviour
             }
             // Instantiate unit temporarily in the scene
             GameObject unitInstance = GameObject.Instantiate(unitPrefab);
+            unitInstance.transform.position = new Vector3(0.0f, -170.0f, 0.0f);
             unitInstance.SetActive(true);
             UnitObject unitObj = unitInstance.GetComponent<UnitObject>();
+            unitObj.Init();
             var so = unitObj.unitSO;
             Sprite unitIcon = GetUnitSprite(unitInstance);
     

--- a/Assets/Resources/Script/StoryTellerManager/StoryTellerManager.cs
+++ b/Assets/Resources/Script/StoryTellerManager/StoryTellerManager.cs
@@ -134,8 +134,10 @@ public class StoryTellerManager : MonoBehaviour
             }
             // Instantiate unit temporarily in the scene
             GameObject unitInstance = GameObject.Instantiate(unitPrefab);
+            unitInstance.transform.position = new Vector3(0.0f, -170.0f, 0.0f);
             unitInstance.SetActive(true);
             UnitObject unitObj = unitInstance.GetComponent<UnitObject>();
+            unitObj.Init();
             var so = unitObj.unitSO;
             finalUnitObject = unitObj;
             Sprite unitIcon = GetUnitSprite(unitInstance);

--- a/Assets/Resources/Script/UIManager/MockScripts/MockPlayerInventoryHolder.cs
+++ b/Assets/Resources/Script/UIManager/MockScripts/MockPlayerInventoryHolder.cs
@@ -36,4 +36,11 @@ public class MockPlayerInventoryHolder : MonoBehaviour
         };
         ItemTracker.Instance.AddOnRemove(TrackerType.BagContainer, onRemoveAction);
     }
+
+    public void ClearInventory()
+    {
+        playerInventory.bagItems.Clear();
+        ItemTracker.Instance.ClearItems();
+        Global.DEBUG_PRINT("[MockPlayerInventoryHolder::ClearInventory] Cleared player inventory and ITEM TRACKER.");
+    }
 }

--- a/Assets/Resources/Script/UIManager/UnitSettingsLayout/UnitDetailsPanel.cs
+++ b/Assets/Resources/Script/UIManager/UnitSettingsLayout/UnitDetailsPanel.cs
@@ -33,69 +33,11 @@ public class UnitDetailsPanel : MonoBehaviour
     private void UpdateUI() 
     {
         if (currentUnit == null) { return; }
-
-        // nameText.text = currentUnit.unitName;
-        // levelText.text = $"Lv {currentUnit.level}";
-        // hpText.text = $"HP: {currentUnit.currentHP} / {currentUnit.maxHP}";
-        // atkText.text = $"ATK: {currentUnit.attack}";
-        // defText.text = $"NOR: {currentUnit.equippedRelics.Count}"; // Placeholder to check relic count
-
-        UpdateEquippedRelics();
     }
 
-    private void UpdateEquippedRelics() {
-        // foreach (Transform child in equippedRelicContainer) {
-        //     Destroy(child.gameObject);
-        // }
-        // foreach (MockRelic relic in currentUnit.equippedRelics) {
-        //     var go = Instantiate(relicSlotPrefab, equippedRelicContainer);
-        //     var slot = go.GetComponent<RelicButton>();
-        //     slot.Init(relic);
-        // }
-    }
+    public string GetAnyUnitName(UnitObject unit) => unit?.unitSO?.GetUnitName() ?? "NULL";
 
-    public string GetAnyUnitName(UnitObject unit) => unit?.unitSO?.unitName ?? "NULL";
-
-    public string GetAnyUnitDetails(UnitObject unit) 
-    {
-        if (unit == null) return "NULL";
-
-        HashSet<EffectType> uniqueTypes = new HashSet<EffectType>();
-
-        void AddFromList(EffectList list)
-        {
-            if (list == null || !list.IsValid()) return;
-            foreach (EffectScriptableObject eff in list)
-            {
-                if (eff == null) continue;
-                uniqueTypes.Add(eff.GetEffectType());
-            }
-        }
-
-        // Gather from all effect lists defined in UnitObject
-        /*AddFromList(unit._listSingleEffect);
-        AddFromList(unit._listHorizontalEffect);
-        AddFromList(unit._listDiagonalEffect);
-        AddFromList(unit._listZigZagEffect);
-        AddFromList(unit._listXShapeEffect);
-        AddFromList(unit._listFullGridEffect);*/
-
-        System.Text.StringBuilder sb = new System.Text.StringBuilder();
-        foreach (EffectType eType in uniqueTypes)
-        {
-            EffectDetailScriptableObject detail = ResourceManager.instance.GetEffectDetail(eType);
-            if (detail != null && !string.IsNullOrEmpty(detail.strDescription))
-            {
-                sb.AppendLine(detail.strDescription);
-            }
-            else
-            {
-                sb.AppendLine(eType.ToString());
-            }
-        }
-
-        return sb.ToString();
-    }
+    public string GetAnyUnitDetails(UnitObject unit) => $"Tier: {unit?.unitSO?.GetUnitTierString()}" ?? "NULL";
 
     public UnitObject GetCurrentUnit() => currentUnit;
 }

--- a/Assets/Resources/Script/UIManager/UnitSettingsLayout/UnitSettingLayout.cs
+++ b/Assets/Resources/Script/UIManager/UnitSettingsLayout/UnitSettingLayout.cs
@@ -209,7 +209,6 @@ public class UnitSettingLayout : MonoBehaviour
                 }
                 GameObject unitGO = Instantiate(unitButtonPrefab, slot);
                 var unitItem = new MockInventoryItem(unit);
-                //unit.uiGameObject = unitGO; // nico: what is this?
                 unitGO.GetComponent<UnitButton>().Init(unit, unitItem, ShowDetails);
                 unitGO.GetComponent<DragHandler>().Init(unitItem);
                 unitGO.GetComponent<ToolTipDetails>().Init(unitDetailsPanel.GetAnyUnitName(unit), unitDetailsPanel.GetAnyUnitDetails(unit));
@@ -242,7 +241,8 @@ public class UnitSettingLayout : MonoBehaviour
         Global.DEBUG_PRINT($"[UnitSettingsLayout::GenerateFixedBagSlots] BagContainer has {tracker.maxItems} slots");
     }
 
-    private void PopulateBagItems() {
+    private void PopulateBagItems() 
+    {
         for (int i = 0; i < bagContainer.childCount; i++) {
             if (i >= inventory.bagItems.Count)
                 break;
@@ -257,6 +257,7 @@ public class UnitSettingLayout : MonoBehaviour
                 unitBtn.Init(item.unitData, item, ShowDetails);
                 unitBtn.boundItem = item;
                 unitBtn.GetComponent<DragHandler>().Init(item);
+                unitBtn.GetComponent<ToolTipDetails>().Init(unitDetailsPanel.GetAnyUnitName(item.unitData), unitDetailsPanel.GetAnyUnitDetails(item.unitData));
             } else // Relic
               {
                 go = Instantiate(relicButtonPrefab, slot);
@@ -289,7 +290,8 @@ public class UnitSettingLayout : MonoBehaviour
         }
     }
 
-    private void PopulateUnitRelics(UnitObject unit) {
+    private void PopulateUnitRelics(UnitObject unit) 
+    {
         int relicIndex = 0;
         List<RelicScriptableObject> listRelic = unit.GetRelic();
         for (int i = 0; i < relicContainer.childCount; i++) {
@@ -304,7 +306,6 @@ public class UnitSettingLayout : MonoBehaviour
 
             go.GetComponent<RelicButton>().Init(relic, relicItem);
             go.GetComponent<DragHandler>().Init(relicItem);
-            //ItemTracker.Instance.AddItem(TrackerType.RelicContainer, MockItemType.Relic);
             // Stretch to fit
             RectTransform rt = go.GetComponent<RectTransform>();
             rt.anchorMin = Vector2.zero;

--- a/Assets/Resources/ScriptableObject/UnitSO/_Base/UnitScriptableObject.cs
+++ b/Assets/Resources/ScriptableObject/UnitSO/_Base/UnitScriptableObject.cs
@@ -73,6 +73,11 @@ public class UnitScriptableObject : ScriptableObject {
         return unitDescription;
     }
 
+    public string GetUnitTierString() 
+    {
+        return eTier.ToString();
+    }
+
     public int GetUnitCost() {
         switch (eTier) {
             case eUnitTier.STAR_1:

--- a/Assets/Scenes/Game_StoryTeller.unity
+++ b/Assets/Scenes/Game_StoryTeller.unity
@@ -607,7 +607,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.25, y: 1.25, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 433493622}
@@ -3551,7 +3551,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 3, y: -4, z: 0}
@@ -3581,7 +3581,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 5, y: -4, z: 0}
@@ -3596,7 +3596,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 6, y: -4, z: 0}
@@ -3926,7 +3926,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -8, y: -2, z: 0}
@@ -3941,7 +3941,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -7, y: -2, z: 0}
@@ -3956,7 +3956,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: -6, y: -2, z: 0}
@@ -4421,7 +4421,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10
+      m_AnimationSpeed: 10.000001
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 7, y: -1, z: 0}
@@ -4586,7 +4586,7 @@ Tilemap:
       - {fileID: 1448541200, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: -759411154, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
       - {fileID: 1881336656, guid: 7b9fed6b3ef890c4eb1eebaef3f236b9, type: 3}
-      m_AnimationSpeed: 10.000001
+      m_AnimationSpeed: 10
       m_AnimationTimeOffset: 0
       m_Flags: 0
   - first: {x: 0, y: 0, z: 0}


### PR DESCRIPTION

# Type Of Change
<!-- Describe type of change in this pull request -->
- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Misc

## Description
<!-- Describe the changes in this pull request -->
Fixed these issues:

Issue 1:
Taking a unit from encounter reduces ur deck pool.
Had 3 Units -> Took 1 from encounter -> Become 2 units
Inventory dont have the other 2 units (the one gone and the one taken)

Issue 4:
Buying units from shophouse reduce 1 units from the player deck in the deck display below
I bought 3 units, and exited, my below deck from 3 units become 2
Seems like the units bought have 0 hp

Issue 5
Claimed or bought Units have 0 Hp it seems

Issue 6:
When i restart the game after dying, items/units in the inventory still stays, not cleared

Issue 7:
There are units lying around at 0,0 when changing scene and all , buying a unit or encountering.
So when we restart game , it renders there too (Game_Map <-> Encounter/Shrine -> MainMenu)

## Related Issues
<!-- Link to any related issues or tasks -->

## Testing Instructions
<!--  Provide steps to test these changes -->

## Example Output
<!--  Provide output as screenshot or video to view expected changes -->